### PR TITLE
Update open() example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,9 @@ modeler.on('elementTemplates.errors', event => {
 
 modeler.get('elementTemplatesLoader').setTemplates(ELEMENT_TEMPLATES_JSON);
 
-// alternatively, choose programmatically
-// from a given list of element templates
-const task = modeler.get('elementRegistry').get('MyTask');
-
+// alternatively, open the chooser programmatically
 const template = await (
-  modeler.get('elementTemplateChooser').open(task, ELEMENT_TEMPLATES_JSON)
+  modeler.get('elementTemplateChooser').open(ELEMENT_TEMPLATES_JSON)
 );
 ```
 


### PR DESCRIPTION
The `open` method accepts only 1 argument, from https://github.com/bpmn-io/element-template-chooser/blob/af5579cf104d172f73a284dd752682fb1a96e14c/src/element-template-chooser/ElementTemplateChooser.js#L99

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
