### PR TITLE
feat: restore focus on the canvas when pop up is closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to [@bpmn-io/element-template-chooser](https://github.com/ca
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FEAT`: restore focus on the canvas when pop up is closed
+
 ## 1.0.0
 
 * `FEAT`: use modern popup menu foundations

--- a/src/ElementTemplateChooser.js
+++ b/src/ElementTemplateChooser.js
@@ -10,18 +10,21 @@ import './ElementTemplateChooser.css';
  * @param {ElementTemplates} elementTemplates
  * @param {Translate} translate
  * @param {PopupMenu} popupMenu
+ * @param {Canvas} canvas
  */
 export default function ElementTemplateChooser(
     config,
     eventBus,
     elementTemplates,
     translate,
-    popupMenu) {
+    popupMenu,
+    canvas) {
 
   this._eventBus = eventBus;
   this._elementTemplates = elementTemplates;
   this._translate = translate;
   this._popupMenu = popupMenu;
+  this._canvas = canvas;
 
   const enableChooser = !config || config.elementTemplateChooser !== false;
 
@@ -44,7 +47,8 @@ ElementTemplateChooser.$inject = [
   'eventBus',
   'elementTemplates',
   'translate',
-  'popupMenu'
+  'popupMenu',
+  'canvas'
 ];
 
 ElementTemplateChooser.prototype.open = function(element) {
@@ -52,10 +56,22 @@ ElementTemplateChooser.prototype.open = function(element) {
   const popupMenu = this._popupMenu;
   const translate = this._translate;
   const eventBus = this._eventBus;
+  const canvas = this._canvas;
+
+  const restoreCanvasFocus = () => {
+
+    // Only available with diagram-js >= 15.0.0
+    if (canvas && canvas.restoreFocus) {
+      canvas.restoreFocus();
+    }
+  };
 
   return new Promise((resolve, reject) => {
 
-    const handleClosed = () => reject('user-canceled');
+    const handleClosed = () => {
+      reject('user-canceled');
+      restoreCanvasFocus();
+    };
 
     eventBus.once('popupMenu.close', handleClosed);
 
@@ -66,6 +82,7 @@ ElementTemplateChooser.prototype.open = function(element) {
       eventBus.off('popupMenu.close', handleClosed);
 
       resolve(template);
+      restoreCanvasFocus();
     });
 
     popupMenu.open(element, 'element-template-chooser', { x: 0, y: 0 }, {

--- a/src/ElementTemplateChooser.js
+++ b/src/ElementTemplateChooser.js
@@ -61,7 +61,7 @@ ElementTemplateChooser.prototype.open = function(element) {
   const restoreCanvasFocus = () => {
 
     // Only available with diagram-js >= 15.0.0
-    if (canvas && canvas.restoreFocus) {
+    if (canvas.restoreFocus) {
       canvas.restoreFocus();
     }
   };


### PR DESCRIPTION
### Proposed Changes

Related to https://github.com/camunda/camunda-modeler/pull/4620
Related to https://github.com/bpmn-io/internal-docs/issues/1081

Utilize new `Canvas#restoreFocus` API to restore focus on the canvas after the pop up closes.
<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
